### PR TITLE
Ensure a 404 response is returned when the zip file is missing

### DIFF
--- a/server/routes/index.js
+++ b/server/routes/index.js
@@ -31,6 +31,12 @@ module.exports = function Index({ storageService }) {
       const fileName = `${req.params.fileName}.zip`;
       const stream = await storageService.downloadFile(fileName);
 
+      if (stream == null) {
+        res.status(404);
+        res.render('pages/404');
+        return;
+      }
+
       stream
         .on('error', (error) => {
           logger.error(error);

--- a/server/services/storage.js
+++ b/server/services/storage.js
@@ -164,11 +164,17 @@ function downloadFile(service) {
         config.azureBlobStorageContainerName,
         blobName,
         (err, props) => {
+          if (err && err.code === 'NotFound') return resolve(null);
           if (err) return reject(err);
           return resolve(props);
         },
       );
     });
+
+    // Resolved from NotFound
+    if (!properties) {
+      return null;
+    }
 
     const stream = service.createReadStream(
       config.azureBlobStorageContainerName,

--- a/test/routes/index.spec.js
+++ b/test/routes/index.spec.js
@@ -120,7 +120,12 @@ describe('GET /', () => {
   describe('Unsuccessful download request', () => {
     it('returns a 404 when an error occurs with the download', async () => {
       const app = setupBasicApp();
-      const service = await storageService(createBlobServiceError());
+      const notFoundError = new Error('NotFound');
+      notFoundError.code = 'NotFound';
+      const blobService = {
+        getBlobProperties: sinon.stub().yields(notFoundError),
+      };
+      const service = await storageService(blobService);
 
       app.use(createIndexRouter({
         storageService: service,

--- a/test/services/storage.spec.js
+++ b/test/services/storage.spec.js
@@ -52,6 +52,20 @@ describe('storageService', () => {
         expect(stream).to.be.an.instanceof(Readable);
       });
     });
+    describe('When the requested file is not available for download', () => {
+      it('returns null', async () => {
+        const notFoundError = new Error('NotFound');
+        notFoundError.code = 'NotFound';
+        const blobService = {
+          getBlobProperties: sinon.stub().yields(notFoundError),
+        };
+        const service = await storageService(blobService);
+
+        const stream = await service.downloadFile('foo.zip');
+
+        expect(stream).to.eql(null);
+      });
+    });
   });
 
   describe('.listFiles', () => {


### PR DESCRIPTION
This was overlooked when I did the extra API call to get metadata properties